### PR TITLE
handle edge case with start.txt

### DIFF
--- a/src/Analyzer/DokuwikiAnalyzer.php
+++ b/src/Analyzer/DokuwikiAnalyzer.php
@@ -62,6 +62,7 @@ class DokuwikiAnalyzer
 			'page-changes-map',
 			'attic-pages-map',
 			'attic-media-map',
+			'start-page-aliases',
 		] );
 		$this->logger = new NullLogger();
 		$this->titleKeyBuilder = new TitleKeyBuilder();
@@ -212,6 +213,8 @@ class DokuwikiAnalyzer
 			// .txt is a direct child of pages directory.
 			// It has to result in a page in NS_MAIN or it is the main page of a namespace.
 			$this->namespaceMainpage( $paths, $file );
+		} else {
+			$this->handleStartPage( $paths, $file );
 		}
 
 		$key = $this->makeTitleKey( $paths );
@@ -246,6 +249,8 @@ class DokuwikiAnalyzer
 		$timestamp = array_pop( $parts );
 		$parts[] = $extension;
 		$paths[$lastKey] = implode( '.', $parts );
+
+		$this->handleStartPage( $paths, $file );
 
 		$key = $this->makeTitleKey( $paths );
 		$this->output->writeln( "Add attic page revision: {$file->getRealPath()}" );
@@ -305,6 +310,47 @@ class DokuwikiAnalyzer
 			$this->output->writeln( "Add changes: {$file->getRealPath()}" );
 			$this->dataBuckets->addData( 'page-changes-map', $key, $file->getPathname(), true, true );
 		}
+	}
+
+	/**
+	 * When foo/start.txt exists without a sibling foo.txt, treat it as the namespace
+	 * main page (equivalent to foo.txt with a foo/ directory). Stores an alias so that
+	 * links like [[foo:start]] resolve to the same page.
+	 * When both foo.txt and foo/start.txt exist, keep start.txt as a separate page.
+	 *
+	 * @param array &$paths
+	 * @param SplFileInfo $file
+	 * @return void
+	 */
+	private function handleStartPage( array &$paths, SplFileInfo $file ): void {
+		if ( count( $paths ) < 2 || $paths[ count( $paths ) - 1 ] !== 'start.txt' ) {
+			return;
+		}
+		if ( file_exists( $this->getStartPageSiblingPath( $file ) ) ) {
+			// Both foo.txt and foo/start.txt exist → keep start.txt as separate page
+			return;
+		}
+		$originalKey = $this->makeTitleKey( $paths );
+		$namespaceName = $paths[ count( $paths ) - 2 ];
+		$paths[ count( $paths ) - 1 ] = $namespaceName . '.txt';
+		$this->dataBuckets->addData( 'start-page-aliases', $originalKey, $this->makeTitleKey( $paths ), false, true );
+	}
+
+	/**
+	 * Returns the path of the sibling foo.txt that would conflict with foo/start.txt.
+	 * Translates attic paths to the corresponding pages path for the check.
+	 *
+	 * @param SplFileInfo $file
+	 * @return string
+	 */
+	private function getStartPageSiblingPath( SplFileInfo $file ): string {
+		$namespaceDir = dirname( $file->getPathname() );
+		$namespaceName = basename( $namespaceDir );
+		$containingDir = dirname( $namespaceDir );
+		// Translate attic/ to pages/ so history files check against current pages
+		$containingDir = str_replace( '/attic/', '/pages/', $containingDir . '/' );
+		$containingDir = rtrim( $containingDir, '/' );
+		return $containingDir . '/' . $namespaceName . '.txt';
 	}
 
 	/**

--- a/src/Converter/DokuwikiConverter.php
+++ b/src/Converter/DokuwikiConverter.php
@@ -74,9 +74,10 @@ class DokuwikiConverter extends PandocDokuwiki implements IOutputAwareInterface 
 	 * @return array
 	 */
 	private function getProcessors(): array {
+		$titleMap = $this->buildTitleMapWithAliases();
 		return [
-			new PreserveInclude( $this->dataBuckets->getBucketData( 'page-id-to-title-map' ) ),
-			new Link( $this->dataBuckets->getBucketData( 'page-id-to-title-map' ) ),
+			new PreserveInclude( $titleMap ),
+			new Link( $titleMap ),
 			new ImageProcessor( $this->dataBuckets->getBucketData( 'media-id-to-title-map' ), $this->advancedConfig )
 		];
 	}
@@ -117,6 +118,7 @@ class DokuwikiConverter extends PandocDokuwiki implements IOutputAwareInterface 
 			'attic-media-map',
 			'page-id-to-title-map',
 			'media-id-to-title-map',
+			'start-page-aliases',
 			// From this step
 		];
 	}
@@ -145,6 +147,24 @@ class DokuwikiConverter extends PandocDokuwiki implements IOutputAwareInterface 
 	 */
 	public function setOutput( Output $output ) {
 		$this->output = $output;
+	}
+
+	/**
+	 * Returns the page title map enriched with start-page aliases so that links
+	 * like [[foo:start]] resolve correctly when foo/start.txt was treated as the
+	 * namespace main page (no conflicting foo.txt present).
+	 *
+	 * @return array
+	 */
+	private function buildTitleMapWithAliases(): array {
+		$titleMap = $this->dataBuckets->getBucketData( 'page-id-to-title-map' );
+		$aliases = $this->dataBuckets->getBucketData( 'start-page-aliases' );
+		foreach ( $aliases as $aliasId => $canonicalId ) {
+			if ( isset( $titleMap[$canonicalId] ) ) {
+				$titleMap[$aliasId] = $titleMap[$canonicalId];
+			}
+		}
+		return $titleMap;
 	}
 
 	/**

--- a/tests/phpunit/Analyzer/DokuwikiAnalyzerStartPageTest.php
+++ b/tests/phpunit/Analyzer/DokuwikiAnalyzerStartPageTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace HalloWelt\MigrateDokuwiki\Tests\Analyzer;
+
+use HalloWelt\MediaWiki\Lib\Migration\DataBuckets;
+use HalloWelt\MediaWiki\Lib\Migration\Workspace;
+use HalloWelt\MigrateDokuwiki\Analyzer\DokuwikiAnalyzer;
+use PHPUnit\Framework\TestCase;
+use SplFileInfo;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Tests the three cases for DokuWiki's start.txt namespace main-page convention:
+ *
+ *  1. Only foo/start.txt  → treated as namespace main page (key foo:foo, alias stored)
+ *  2. Only foo.txt        → existing namespace main-page behaviour unchanged (key foo:foo)
+ *  3. Both foo.txt AND foo/start.txt → foo.txt stays foo:foo, start.txt becomes foo:start
+ *
+ * @covers \HalloWelt\MigrateDokuwiki\Analyzer\DokuwikiAnalyzer
+ */
+class DokuwikiAnalyzerStartPageTest extends TestCase {
+
+	/** @var string */
+	private $tmpDir;
+
+	protected function setUp(): void {
+		$this->tmpDir = sys_get_temp_dir() . '/dw-analyzer-test-' . uniqid();
+		mkdir( $this->tmpDir, 0777, true );
+	}
+
+	protected function tearDown(): void {
+		$this->removeDir( $this->tmpDir );
+	}
+
+	// -------------------------------------------------------------------------
+	// Tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * foo/start.txt alone → treated as namespace main page.
+	 * pages-map key must be foo:foo; alias foo:start → foo:foo must be stored.
+	 */
+	public function testOnlyStartTxtIsNamespaceMainPage(): void {
+		$src = $this->makeSrc( [
+			'pages/foo/start.txt' => 'content',
+		] );
+
+		[ $pagesMap, $aliases ] = $this->runAnalyzer( $src, [ 'pages/foo/start.txt' ] );
+
+		$this->assertArrayHasKey( 'foo:foo', $pagesMap, 'start.txt alone must be stored under foo:foo' );
+		$this->assertArrayNotHasKey( 'foo:start', $pagesMap, 'foo:start must not appear in pages-map when there is no conflict' );
+		$this->assertSame( 'foo:foo', $aliases['foo:start'] ?? null, 'alias foo:start → foo:foo must be stored' );
+	}
+
+	/**
+	 * foo.txt with a foo/ directory → existing behaviour: namespace main page.
+	 * pages-map key must be foo:foo; no aliases must be stored.
+	 */
+	public function testOnlyFooTxtIsNamespaceMainPage(): void {
+		$src = $this->makeSrc( [
+			'pages/foo.txt'       => 'content',
+			'pages/foo/.keep'     => '',   // the foo/ directory must exist for namespaceMainpage
+		] );
+
+		[ $pagesMap, $aliases ] = $this->runAnalyzer( $src, [ 'pages/foo.txt' ] );
+
+		$this->assertArrayHasKey( 'foo:foo', $pagesMap, 'foo.txt with foo/ dir must be stored under foo:foo' );
+		$this->assertEmpty( $aliases, 'no aliases expected when only foo.txt is present' );
+	}
+
+	/**
+	 * Both foo.txt and foo/start.txt present → foo.txt keeps foo:foo,
+	 * start.txt becomes the distinct page foo:start; no alias stored.
+	 */
+	public function testBothPresentCreatesDistinctStartPage(): void {
+		$src = $this->makeSrc( [
+			'pages/foo.txt'       => 'content',
+			'pages/foo/start.txt' => 'start content',
+		] );
+
+		[ $pagesMap, $aliases ] = $this->runAnalyzer( $src, [ 'pages/foo.txt', 'pages/foo/start.txt' ] );
+
+		$this->assertArrayHasKey( 'foo:foo', $pagesMap, 'foo.txt must be stored under foo:foo' );
+		$this->assertArrayHasKey( 'foo:start', $pagesMap, 'start.txt must be stored under foo:start when both exist' );
+		$this->assertEmpty( $aliases, 'no alias expected when both foo.txt and foo/start.txt are present' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Creates the source directory tree and returns its path.
+	 *
+	 * @param array $files  relative path => content
+	 * @return string absolute path to the source root
+	 */
+	private function makeSrc( array $files ): string {
+		$src = $this->tmpDir . '/src';
+		foreach ( $files as $rel => $content ) {
+			$abs = $src . '/' . $rel;
+			mkdir( dirname( $abs ), 0777, true );
+			file_put_contents( $abs, $content );
+		}
+		return $src;
+	}
+
+	/**
+	 * Instantiates and runs the analyzer for the given relative file paths,
+	 * then returns [pages-map, start-page-aliases].
+	 *
+	 * @param string $src       absolute source root
+	 * @param string[] $relPaths  paths relative to $src to analyze
+	 * @return array{0: array, 1: array}
+	 */
+	private function runAnalyzer( string $src, array $relPaths ): array {
+		$wsDir = $this->tmpDir . '/workspace';
+		mkdir( $wsDir, 0777, true );
+		$workspace = new Workspace( new SplFileInfo( $wsDir ) );
+
+		$buckets = new DataBuckets( [] );
+		$analyzer = DokuwikiAnalyzer::factory( [], $workspace, $buckets );
+		$analyzer->setSourcePath( $src . '/' );
+		$analyzer->setOutput( new BufferedOutput() );
+
+		foreach ( $relPaths as $rel ) {
+			$analyzer->analyze( new SplFileInfo( $src . '/' . $rel ) );
+		}
+
+		// Read back from workspace (the analyzer saves after each file)
+		$result = new DataBuckets( [ 'pages-map', 'start-page-aliases' ] );
+		$result->loadFromWorkspace( $workspace );
+
+		return [
+			$result->getBucketData( 'pages-map' ),
+			$result->getBucketData( 'start-page-aliases' ),
+		];
+	}
+
+	/**
+	 * Recursively removes a directory.
+	 */
+	private function removeDir( string $dir ): void {
+		if ( !is_dir( $dir ) ) {
+			return;
+		}
+		foreach ( scandir( $dir ) as $entry ) {
+			if ( $entry === '.' || $entry === '..' ) {
+				continue;
+			}
+			$path = $dir . '/' . $entry;
+			is_dir( $path ) ? $this->removeDir( $path ) : unlink( $path );
+		}
+		rmdir( $dir );
+	}
+}


### PR DESCRIPTION
If we’ve got both foo.txt and foo/start.txt, we need to migrate
both. We’ll now create a foo/start page in this case. Otherwise,
if only one of them is there, we keep the “create foo page”
behaviour.

ERM45448
