### PR TITLE
revert double path stripping

### DIFF
--- a/src/Utility/TitleBuilder.php
+++ b/src/Utility/TitleBuilder.php
@@ -85,10 +85,6 @@ class TitleBuilder {
 		$subpageText = array_pop( $paths );
 
 		for ( $index = 0; $index < count( $paths ); $index++ ) {
-			if ( ( $index === count( $paths ) - 1 )
-				&& $paths[$index] === $subpageText ) {
-				break;
-			}
 			$this->appendTitleSegment( $paths[$index] );
 		}
 

--- a/src/Utility/TitleKeyBuilder.php
+++ b/src/Utility/TitleKeyBuilder.php
@@ -13,17 +13,7 @@ class TitleKeyBuilder {
 	 */
 	public function build( array $paths ): string {
 		$this->makeTitleKeyFromPaths( $paths );
-
-		$reverse = array_reverse( $this->titleSegments );
-		if ( isset( $reverse[2] ) && $reverse[0] === $reverse[1] ) {
-			// some dokuwiki have the subpage content inside the directory,
-			// ohters inside the parent directory. The first case prduces a double
-			// key which creates a double title part.
-			array_pop( $this->titleSegments );
-		}
-
-		$key = implode( ':', $this->titleSegments );
-		return $key;
+		return implode( ':', $this->titleSegments );
 	}
 
 	/**


### PR DESCRIPTION
This commit handles pages of the form

    namespace:target:target

and according files

    namespace/target/target.txt

According to https://www.dokuwiki.org/namespaces this should be a page
"target" in the namespace "namespace:target". Based on a previous
migration we stripped the last part away, leading to a MediaWiki page

    Namespace:Target

However, if a DokuWiki page

    namespace:target
    namespace/target.txt

exists, it shadowed the nested one completely. I.e., the nested one
didn’t get migrated at all.

We now keep the file name duplication intact, creating a MediaWiki page

    Namespace:Target/Target

Disadvantage: For sites with loose structure (i.e., lots of foo/foo.txt
without foo.txt) we will create a lot of empty root pages.

ERM45448
